### PR TITLE
Add the missing Delete job/{id} operation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -133,6 +133,11 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/Job'
+    delete:
+      summary: Delete Jobs
+      responses:
+        '204':
+          description: No Content
   /jobs/{id}/job-application:
     parameters:
       - schema:


### PR DESCRIPTION
Add the missing DELETE /job/{id} operation.
I believe we’ll need this when the user wants to delete the Job.